### PR TITLE
Modified update-client.sh script to perform faster client upgrades without stopping the services

### DIFF
--- a/update-client.sh
+++ b/update-client.sh
@@ -29,8 +29,9 @@ read -p "Hit [Enter] to Continue OR Ctrl+C to Cancel"
 
 echo -e "\nStep 1: Stop PulseChain clients (Geth and Lighthouse)"
 
-# stop client services
-sudo systemctl stop geth lighthouse-beacon lighthouse-validator
+# Commented out this part, let's continue validating! once we have pulled the latest changes and 
+# built the latest binaries we will gracefully restart the processes to run the latest changes
+# sudo systemctl stop geth lighthouse-beacon lighthouse-validator
 
 # update git config
 sudo -u $NODE_USER bash -c "cd \$HOME && git config --global user.name client"
@@ -53,7 +54,7 @@ sudo -u $NODE_USER bash -c "cd \$HOME && source \$HOME/.cargo/env && cd /opt/lig
 
 echo -e "\nStep 3: Starting PulseChain clients"
 
-# start updated services
-sudo systemctl start geth lighthouse-beacon lighthouse-validator
+# restart updated services to gracefully stop "old" binaries and start the newly built ones
+sudo systemctl restart geth lighthouse-beacon lighthouse-validator
 
 echo -e "\nProcess is complete"


### PR DESCRIPTION
Turns out that we can just pull the latest changes for the repo and start the build process (which replaces the currently run binaries) without doing a `systemctl stop` command, the `systemctl restart` will still gracefully stop the services, and after running a successful update (`git pull && make`) on the repos will restart loading the newly updated binaries into memory and starting the validation process without minimum downtime.

New downtime < `1 minute`
Old downtime `~45 - ~1 hour`

### Testing
Spun up a new EC2 instance ran the setup script building both versions v2.2.0.
After it was done, I was tailing the logs for `geth` and `lighthouse beacon` services via `journalctl` verified that while building the binaries these 2 services were running, and after upgrading both to v3.0.0 the `systemctl restart` would stop and start them successfully.